### PR TITLE
[Package Manager] Add fpm support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,34 @@ A modern Fortran library for reading and writing CSV (comma-separated value) fil
 
 [![GitHub release](https://img.shields.io/github/release/jacobwilliams/fortran-csv-module.svg?style=plastic)](https://github.com/jacobwilliams/fortran-csv-module/releases/latest)
 
+### Getting started
+#### Get the code
+```bash
+git clone https://github.com/jacobwilliams/fortran-csv-module
+cd fortran-csv-module
+```
+#### Dependencies
+1. Git
+2. FoBis or [fpm](https://github.com/fortran-lang/fpm)
+3. Ford (optional)
+#### Build with FoBis
+You can build using provided `build.sh`:
+```bash
+./build.sh
+```
+
+#### Build with [fortran-lang/fpm](https://github.com/fortran-lang/fpm)
+Fortran Package Manager (fpm) is a great package manager and build system for Fortran.  
+You can build using provided `fpm.toml`:
+```bash
+fpm build
+```
+To use `fortran-csv-module` within your fpm project, add the following to your `fpm.toml` file:
+```toml
+[dependencies]
+fortran-csv-module = { git="https://github.com/jacobwilliams/fortran-csv-module.git" }
+```
+
 ### Examples
 
 Everything is handled by an object-oriented `csv_file` class. Here is an example for writing a file:

--- a/fpm.toml
+++ b/fpm.toml
@@ -1,0 +1,11 @@
+name = "fortran-csv-module"
+author = "Jacob Williams"
+version = "1.2.0"
+license = "BSD-3"
+copyright = "Copyright 2017 Jacob Williams"
+description = "A modern Fortran library for reading and writing CSV (comma-separated value) files."
+categories = ["io"]
+keywords = ["csv"]
+
+[library]
+source-dir = "src"


### PR DESCRIPTION
Added `fpm` support for `fortran-csv-module`:
1. Added a`fpm.toml` file;
2. Added the build tutorial instructions in `readme.md`.

#### Fpm Test
Unfortunately, Relative path files is used in the test programs. I didn't think of a proper way to handle the relationship between `FoBis` and `fpm`, so the fpm test capability was not added.