### PR TITLE
fix issue #17, status_ok=.true. for read_header() and variable_types()

### DIFF
--- a/src/csv_module.F90
+++ b/src/csv_module.F90
@@ -614,7 +614,7 @@
         do i=1,me%n_cols
             header(i) = me%header(i)
         end do
-        status_ok = .false.
+        status_ok = .true.
 
     else
         if (me%verbose) write(error_unit,'(A)') 'Error: no header in class.'
@@ -645,7 +645,7 @@
         do i=1,me%n_cols
             header(i) = me%header(i)%str
         end do
-        status_ok = .false.
+        status_ok = .true.
 
     else
         if (me%verbose) write(error_unit,'(A)') 'Error: no header in class.'
@@ -804,6 +804,7 @@
         do i=1,me%n_cols
             call infer_variable_type(me%csv_data(1,i)%str,itypes(i))
         end do
+        status_ok = .true.
     else
         if (me%verbose) write(error_unit,'(A,1X,I5)') 'Error: class has not been initialized'
         status_ok = .false.


### PR DESCRIPTION
If you conclude that #17 is indeed a bug, then this pull request may save you a few seconds of typing.

I also added a similar `status_ok=.true.` after line [806](https://github.com/jacobwilliams/fortran-csv-module/blob/edc2061f4c59ddc1fea738c27989f6ecdb0d89ed/src/csv_module.F90#L806) in variable_types(). This was the only other occurrence I could find in _csv_module.F90_ where an `intent(out) :: status_ok` was declared, but never set to `.true.`.