### PR TITLE
Retain the values set with initialize_csv_file

### DIFF
--- a/src/csv_module.F90
+++ b/src/csv_module.F90
@@ -226,7 +226,6 @@
                                 !! (0 if no header specified)
     character(len=1) :: tmp     !! for skipping a row
 
-    call me%destroy()
     arrays_allocated = .false.
 
     open(newunit=iunit, file=filename, status='OLD', iostat=istat)
@@ -287,7 +286,9 @@
                 ! columns.
                 n_cols = size(row_data)
                 me%n_cols = n_cols
+                if(allocated(me%csv_data)) deallocate(me%csv_data)
                 allocate(me%csv_data(n_rows,n_cols))
+                if(allocated(me%header)) deallocate(me%header)
                 if (iheader/=0) allocate(me%header(n_cols))
                 arrays_allocated = .true.
             end if
@@ -338,8 +339,6 @@
     integer :: istat       !! open `iostat` flag
     logical :: append_flag !! local copy of `append` argument
     logical :: file_exists !! if the file exists
-
-    call me%destroy()
 
     me%n_cols = n_cols
 


### PR DESCRIPTION
Calling `destroy_csv_file` at the start of `read_csv_file` and `open_csv_file` clobbers any non-default settings e.g. new choice of delimiter is ignored.